### PR TITLE
Make wheel build reproducible

### DIFF
--- a/rules/repository.bzl
+++ b/rules/repository.bzl
@@ -32,12 +32,22 @@ def _pip_repository_impl(repo_ctx):
             attr = "pip_repository",
         )
 
-    r = repo_ctx.execute([
-        repo_ctx.attr.python_interpreter,
-        create_repo_exe_path,
-        repo_directory,
-        requirements_path,
-    ] + repo_ctx.attr.wheel_args)
+    r = repo_ctx.execute(
+        [
+            repo_ctx.attr.python_interpreter,
+            create_repo_exe_path,
+            repo_directory,
+            requirements_path,
+        ] + repo_ctx.attr.wheel_args,
+        environment = {
+            # These make the wheel build reproducible
+            # See https://github.com/bazelbuild/rules_python/issues/154
+            "SOURCE_DATE_EPOCH": "1575327885",
+            "CFLAGS": "-g0",
+            "PYTHONHASHSEED": "0",
+        },
+    )
+
     if r.return_code:
         fail(r.stderr)
 


### PR DESCRIPTION
When building wheels for packages, `pip`/`bdist_wheel` may not generate the exact same binary output for C extensions for a few different reasons:
* current timestamp is used in the build, can be overridden via `SOURCE_DATE_EPOCH` environment variable
* `-g` is used which adds a tmp directory file path to the debuginfo of the binary, can be overridden with `CFLAGS` environment variable
* Python hashing with a random seed, can be overridden by `PYTHONHASHSEED` environment variable

See https://github.com/bazelbuild/rules_python/issues/154 for more details